### PR TITLE
hmac: Fix order of addresses in pseudo-header.

### DIFF
--- a/hmac.c
+++ b/hmac.c
@@ -142,9 +142,9 @@ compute_hmac(const unsigned char *src, const unsigned char *dst,
 	SHA1_Update(&inner_ctx, inner_key_pad, SHA1_BLOCK_SIZE);
 
 	/* Hashing the pseudo header. */
-	SHA1_Update(&inner_ctx, dst, 16);
-	SHA1_Update(&inner_ctx, &port, 2);
 	SHA1_Update(&inner_ctx, src, 16);
+	SHA1_Update(&inner_ctx, &port, 2);
+	SHA1_Update(&inner_ctx, dst, 16);
 	SHA1_Update(&inner_ctx, &port, 2);
 
 	SHA1_Update(&inner_ctx, packet_header, 4);


### PR DESCRIPTION
draft-do-babel-hmac-00 specifies that the HMAC pseudo-header should have
source address and port before destination address and port. Fix the hmac
code to comply with this.

Signed-off-by: Toke Høiland-Jørgensen <toke@toke.dk>